### PR TITLE
Add `Is::associativeArray()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Added
+
+- `Is::associativeArray()`
+
 ## 1.4.0 - 2024-03-24
 
 ### Added

--- a/src/AssociativeArray.php
+++ b/src/AssociativeArray.php
@@ -1,0 +1,111 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Validation;
+
+use Innmind\Immutable\{
+    Validation,
+    Map,
+    Predicate,
+    Pair,
+};
+
+/**
+ * @template K
+ * @template V
+ * @implements Constraint<mixed, Map<K, V>>
+ * @psalm-immutable
+ */
+final class AssociativeArray implements Constraint
+{
+    private function __construct(
+        /** @var Constraint<mixed, K> */
+        private Constraint $key,
+        /** @var Constraint<mixed, V> */
+        private Constraint $value,
+    ) {
+    }
+
+    public function __invoke(mixed $value): Validation
+    {
+        return Is::array()($value)->flatMap($this->validate(...));
+    }
+
+    /**
+     * @psalm-pure
+     * @template A
+     * @template B
+     *
+     * @param Constraint<mixed, A> $key
+     * @param Constraint<mixed, B> $value
+     *
+     * @return self<A, B>
+     */
+    public static function of(Constraint $key, Constraint $value): self
+    {
+        return new self($key, $value);
+    }
+
+    public function and(Constraint $constraint): Constraint
+    {
+        return AndConstraint::of($this, $constraint);
+    }
+
+    public function or(Constraint $constraint): Constraint
+    {
+        return OrConstraint::of($this, $constraint);
+    }
+
+    public function map(callable $map): Constraint
+    {
+        return namespace\Map::of($this, $map);
+    }
+
+    public function asPredicate(): Predicate
+    {
+        return namespace\Predicate::of($this);
+    }
+
+    /**
+     * @return Validation<Failure, Map<K, V>>
+     */
+    private function validate(array $array): Validation
+    {
+        /** @var Validation<Failure, Map<K, V>> */
+        $validation = Validation::success(Map::of());
+
+        /** @var mixed $value */
+        foreach ($array as $key => $value) {
+            /**
+             * @psalm-suppress ArgumentTypeCoercion Due to the non-empty-string for value failures
+             * @var Validation<Failure, Pair<K, V>>
+             */
+            $pair = ($this->key)($key)
+                ->mapFailures(
+                    static fn($failure) => $failure->under(\sprintf(
+                        'key(%s)',
+                        $key,
+                    )),
+                )
+                ->flatMap(
+                    fn($parsedKey) => ($this->value)($value)
+                        ->map(
+                            static fn($value) => new Pair($parsedKey, $value),
+                        )
+                        ->mapFailures(
+                            static fn($failure) => $failure->under(match ($key) {
+                                '' => "''",
+                                default => (string) $key,
+                            }),
+                        ),
+                );
+
+            $validation = $validation->and(
+                $pair,
+                static fn($map, $pair) => ($map)($pair->key(), $pair->value()),
+            );
+        }
+
+        return $validation;
+    }
+}

--- a/src/Is.php
+++ b/src/Is.php
@@ -138,6 +138,21 @@ final class Is implements Constraint
         return Shape::of($key, $constraint);
     }
 
+    /**
+     * @psalm-pure
+     * @template K
+     * @template V
+     *
+     * @param Constraint<mixed, K> $key
+     * @param Constraint<mixed, V> $value
+     *
+     * @return AssociativeArray<K, V>
+     */
+    public static function associativeArray(Constraint $key, Constraint $value): AssociativeArray
+    {
+        return AssociativeArray::of($key, $value);
+    }
+
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);


### PR DESCRIPTION
It's common that HTTP APIs use an associative array as a response format. One example is Packagist endpoint returning the list of packages of an organization where the package name is the key and the details as the value.

This PR adds `Is::associativeArray($keyConstraint, $valueConstraint)` to solve parsing this kind of case.

The parsed value is a `Innmind\Immutable\Map` instead of an associative array to allow the key constraint to be mapped to any type.