### PR TITLE
Custom error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - `Is::associativeArray()`
 - `Has::key()->withFailure()` to change the failure message
+- `Is::string|int|float|array|bool|null()->withFailure()` to change the failure message
+- `PointInTime::ofFormat()->withFailure()` to change the failure message
+- `Is::shape()->withKeyFailure()` to change the failure message for when a key doesn't exist
 
 ## 1.4.0 - 2024-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - `Is::associativeArray()`
+- `Has::key()->withFailure()` to change the failure message
 
 ## 1.4.0 - 2024-03-24
 

--- a/proofs/is.php
+++ b/proofs/is.php
@@ -52,6 +52,38 @@ return static function() {
     );
 
     yield proof(
+        'Is::string()->withFailure()',
+        given(
+            Set\Strings::atLeast(1),
+            Set\Either::any(
+                Set\Integers::any(),
+                Set\RealNumbers::any(),
+                Set\Elements::of(
+                    true,
+                    false,
+                    null,
+                    new stdClass,
+                ),
+                Set\Sequence::of(Set\Strings::any()),
+            ),
+        ),
+        static function($assert, $message, $other) {
+            $assert->same(
+                [['$', $message]],
+                Is::string()->withFailure($message)($other)->match(
+                    static fn() => null,
+                    static fn($failures) => $failures
+                        ->map(static fn($failure) => [
+                            $failure->path()->toString(),
+                            $failure->message(),
+                        ])
+                        ->toList(),
+                ),
+            );
+        },
+    );
+
+    yield proof(
         'Is::int()',
         given(
             Set\Integers::any(),

--- a/proofs/is.php
+++ b/proofs/is.php
@@ -474,6 +474,39 @@ return static function() {
     );
 
     yield proof(
+        'Is::shape()->withKeyFailure()',
+        given(
+            Set\Composite::immutable(
+                static fn($letter, $rest) => $letter.$rest,
+                Set\Either::any(
+                    Set\Chars::lowercaseLetter(),
+                    Set\Chars::uppercaseLetter(),
+                ),
+                Set\Strings::madeOf(Set\Chars::alphanumerical()),
+            ),
+            Set\Strings::atLeast(1),
+        ),
+        static function($assert, $key, $expected) {
+            $assert->same(
+                [['$', $expected]],
+                Is::shape($key, Is::int())->withKeyFailure(static function($in) use ($assert, $key, $expected) {
+                    $assert->same($key, $in);
+
+                    return $expected;
+                })([])->match(
+                    static fn() => null,
+                    static fn($failures) => $failures
+                        ->map(static fn($failure) => [
+                            $failure->path()->toString(),
+                            $failure->message(),
+                        ])
+                        ->toList(),
+                ),
+            );
+        },
+    );
+
+    yield proof(
         'Is::associativeArray()',
         given(
             Set\Sequence::of(Set\Strings::any()->filter(

--- a/proofs/pointInTime.php
+++ b/proofs/pointInTime.php
@@ -50,4 +50,27 @@ return static function() {
                 ->endsWith($format->toString());
         },
     );
+
+    yield proof(
+        'PointInTime::ofFormat()->withFailure()',
+        given(
+            Set\Strings::atLeast(1),
+            Set\Strings::any(),
+        ),
+        static function($assert, $expected, $random) {
+            $format = new ISO8601;
+            $clock = new Clock;
+
+            [[$path, $message]] = PointInTime::ofFormat($clock, $format)->withFailure($expected)($random)->match(
+                static fn() => null,
+                static fn($failures) => $failures
+                    ->map(static fn($failure) => [
+                        $failure->path()->toString(),
+                        $failure->message(),
+                    ])
+                    ->toList(),
+            );
+            $assert->same($expected, $message);
+        },
+    );
 };

--- a/src/Is.php
+++ b/src/Is.php
@@ -20,15 +20,22 @@ final class Is implements Constraint
     private $assert;
     /** @var non-empty-string */
     private string $type;
+    /** @var ?non-empty-string */
+    private ?string $message;
 
     /**
      * @param pure-callable(T): bool $assert
      * @param non-empty-string $type
+     * @param ?non-empty-string $message
      */
-    private function __construct(callable $assert, string $type)
-    {
+    private function __construct(
+        callable $assert,
+        string $type,
+        ?string $message = null,
+    ) {
         $this->assert = $assert;
         $this->type = $type;
+        $this->message = $message;
     }
 
     public function __invoke(mixed $value): Validation
@@ -36,7 +43,9 @@ final class Is implements Constraint
         /** @var Validation<Failure, U> */
         return match (($this->assert)($value)) {
             true => Validation::success($value),
-            false => Validation::fail(Failure::of("Value is not of type {$this->type}")),
+            false => Validation::fail(Failure::of(
+                $this->message ?? "Value is not of type {$this->type}",
+            )),
         };
     }
 
@@ -104,6 +113,16 @@ final class Is implements Constraint
     {
         /** @var self<mixed, null> */
         return new self(\is_null(...), 'null');
+    }
+
+    /**
+     * @param non-empty-string $message
+     *
+     * @return self<T, U>
+     */
+    public function withFailure(string $message): self
+    {
+        return new self($this->assert, $this->type, $message);
     }
 
     /**

--- a/src/Is.php
+++ b/src/Is.php
@@ -116,16 +116,6 @@ final class Is implements Constraint
     }
 
     /**
-     * @param non-empty-string $message
-     *
-     * @return self<T, U>
-     */
-    public function withFailure(string $message): self
-    {
-        return new self($this->assert, $this->type, $message);
-    }
-
-    /**
      * @psalm-pure
      *
      * @template E
@@ -170,6 +160,16 @@ final class Is implements Constraint
     public static function associativeArray(Constraint $key, Constraint $value): AssociativeArray
     {
         return AssociativeArray::of($key, $value);
+    }
+
+    /**
+     * @param non-empty-string $message
+     *
+     * @return self<T, U>
+     */
+    public function withFailure(string $message): self
+    {
+        return new self($this->assert, $this->type, $message);
     }
 
     public function and(Constraint $constraint): Constraint


### PR DESCRIPTION
While the default error messages are clear enough, one may want to change them. It could be the case to output errors in different languages or use translation keys to translate them afterwards.