### PR TITLE
Fix Psalm losing types of contraints when composing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Psalm losing the types of contraints when composing them via `and`, `or`, `map` and `asPredicate`
+
 ## 1.6.0 - 2024-11-11
 
 ### Added

--- a/src/AndConstraint.php
+++ b/src/AndConstraint.php
@@ -56,21 +56,45 @@ final class AndConstraint implements Constraint
         return new self($a, $b);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<C, T> $constraint
+     *
+     * @return self<A, C, T>
+     */
     public function and(Constraint $constraint): self
     {
         return new self($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<A, T> $constraint
+     *
+     * @return Constraint<A, C|T>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param pure-callable(C): T $map
+     *
+     * @return Constraint<A, T>
+     */
     public function map(callable $map): Constraint
     {
         return Map::of($this, $map);
     }
 
+    /**
+     * @return PredicateInterface<C>
+     */
     public function asPredicate(): PredicateInterface
     {
         return Predicate::of($this);

--- a/src/AssociativeArray.php
+++ b/src/AssociativeArray.php
@@ -46,21 +46,45 @@ final class AssociativeArray implements Constraint
         return new self($key, $value);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<Map<K, V>, T> $constraint
+     *
+     * @return Constraint<mixed, T>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<mixed, T> $constraint
+     *
+     * @return Constraint<mixed, Map<K, V>|T>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param pure-callable(Map<K, V>): T $map
+     *
+     * @return Constraint<mixed, T>
+     */
     public function map(callable $map): Constraint
     {
         return namespace\Map::of($this, $map);
     }
 
+    /**
+     * @return Predicate<Map<K, V>>
+     */
     public function asPredicate(): Predicate
     {
         return namespace\Predicate::of($this);

--- a/src/Each.php
+++ b/src/Each.php
@@ -56,21 +56,45 @@ final class Each implements Constraint
         return new self($constraint);
     }
 
+    /**
+     * @template V
+     *
+     * @param Constraint<list<T>, V> $constraint
+     *
+     * @return Constraint<list, V>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template V
+     *
+     * @param Constraint<list, V> $constraint
+     *
+     * @return Constraint<list, list<T>|V>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template V
+     *
+     * @param pure-callable(list<T>): V $map
+     *
+     * @return Constraint<list, V>
+     */
     public function map(callable $map): Constraint
     {
         return Map::of($this, $map);
     }
 
+    /**
+     * @return PredicateInterface<list<T>>
+     */
     public function asPredicate(): PredicateInterface
     {
         return Predicate::of($this);

--- a/src/Has.php
+++ b/src/Has.php
@@ -63,21 +63,45 @@ final class Has implements Constraint
         return new self($this->key, $message);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<mixed, T> $constraint
+     *
+     * @return Constraint<array, T>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<array, T> $constraint
+     *
+     * @return Constraint<array, mixed|T>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param pure-callable(mixed): T $map
+     *
+     * @return Constraint<array, T>
+     */
     public function map(callable $map): Constraint
     {
         return Map::of($this, $map);
     }
 
+    /**
+     * @return PredicateInterface<mixed>
+     */
     public function asPredicate(): PredicateInterface
     {
         return Predicate::of($this);

--- a/src/Instance.php
+++ b/src/Instance.php
@@ -52,21 +52,45 @@ final class Instance implements Constraint
         return new self(Predicate\Instance::of($class), $class);
     }
 
+    /**
+     * @template V
+     *
+     * @param Constraint<T, V> $constraint
+     *
+     * @return Constraint<mixed, V>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template V
+     *
+     * @param Constraint<mixed, V> $constraint
+     *
+     * @return Constraint<mixed, T|V>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template V
+     *
+     * @param pure-callable(T): V $map
+     *
+     * @return Constraint<mixed, V>
+     */
     public function map(callable $map): Constraint
     {
         return Map::of($this, $map);
     }
 
+    /**
+     * @return Predicate<T>
+     */
     public function asPredicate(): Predicate
     {
         return $this->assert;

--- a/src/Is.php
+++ b/src/Is.php
@@ -192,21 +192,45 @@ final class Is implements Constraint
         return new self($this->assert, $this->type, $message);
     }
 
+    /**
+     * @template V
+     *
+     * @param Constraint<U, V> $constraint
+     *
+     * @return Constraint<T, V>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template V
+     *
+     * @param Constraint<T, V> $constraint
+     *
+     * @return Constraint<T, U|V>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template V
+     *
+     * @param pure-callable(U): V $map
+     *
+     * @return Constraint<T, V>
+     */
     public function map(callable $map): Constraint
     {
         return Map::of($this, $map);
     }
 
+    /**
+     * @return PredicateInterface<U>
+     */
     public function asPredicate(): PredicateInterface
     {
         return Predicate::of($this);

--- a/src/Map.php
+++ b/src/Map.php
@@ -53,21 +53,45 @@ final class Map implements Constraint
         return new self($constraint, $map);
     }
 
+    /**
+     * @template V
+     *
+     * @param Constraint<T, V> $constraint
+     *
+     * @return Constraint<I, V>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template V
+     *
+     * @param Constraint<I, V> $constraint
+     *
+     * @return Constraint<I, T|V>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template V
+     *
+     * @param pure-callable(T): V $map
+     *
+     * @return self<I, T, V>
+     */
     public function map(callable $map): self
     {
         return new self($this, $map);
     }
 
+    /**
+     * @return PredicateInterface<T>
+     */
     public function asPredicate(): PredicateInterface
     {
         return Predicate::of($this);

--- a/src/Of.php
+++ b/src/Of.php
@@ -46,21 +46,45 @@ final class Of implements Constraint
         return new self($assert);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<B, T> $constraint
+     *
+     * @return Constraint<A, T>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<A, T> $constraint
+     *
+     * @return Constraint<A, B|T>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param pure-callable(B): T $map
+     *
+     * @return Constraint<A, T>
+     */
     public function map(callable $map): Constraint
     {
         return Map::of($this, $map);
     }
 
+    /**
+     * @return PredicateInterface<B>
+     */
     public function asPredicate(): PredicateInterface
     {
         return Predicate::of($this);

--- a/src/OrConstraint.php
+++ b/src/OrConstraint.php
@@ -56,21 +56,45 @@ final class OrConstraint implements Constraint
         return new self($a, $b);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<B|C, T> $constraint
+     *
+     * @return Constraint<A, T>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<A, T> $constraint
+     *
+     * @return self<A, B|C, T>
+     */
     public function or(Constraint $constraint): self
     {
         return new self($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param pure-callable(B|C): T $map
+     *
+     * @return Constraint<A, T>
+     */
     public function map(callable $map): Constraint
     {
         return Map::of($this, $map);
     }
 
+    /**
+     * @return PredicateInterface<B|C>
+     */
     public function asPredicate(): PredicateInterface
     {
         return Predicate::of($this);

--- a/src/PointInTime.php
+++ b/src/PointInTime.php
@@ -63,21 +63,45 @@ final class PointInTime implements Constraint
         return new self($this->clock, $this->format, $message);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<PointInTimeInterface, T> $constraint
+     *
+     * @return Constraint<string, T>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<string, T> $constraint
+     *
+     * @return Constraint<string, PointInTimeInterface|T>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param pure-callable(PointInTimeInterface): T $map
+     *
+     * @return Constraint<string, T>
+     */
     public function map(callable $map): Constraint
     {
         return Map::of($this, $map);
     }
 
+    /**
+     * @return PredicateInterface<PointInTimeInterface>
+     */
     public function asPredicate(): PredicateInterface
     {
         return Predicate::of($this);

--- a/src/Shape.php
+++ b/src/Shape.php
@@ -160,21 +160,45 @@ final class Shape implements Constraint
         );
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<non-empty-array<non-empty-string, mixed>, T> $constraint
+     *
+     * @return Constraint<mixed, T>
+     */
     public function and(Constraint $constraint): Constraint
     {
         return AndConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param Constraint<mixed, T> $constraint
+     *
+     * @return Constraint<mixed, non-empty-array<non-empty-string, mixed>|T>
+     */
     public function or(Constraint $constraint): Constraint
     {
         return OrConstraint::of($this, $constraint);
     }
 
+    /**
+     * @template T
+     *
+     * @param pure-callable(non-empty-array<non-empty-string, mixed>): T $map
+     *
+     * @return Constraint<mixed, T>
+     */
     public function map(callable $map): Constraint
     {
         return Map::of($this, $map);
     }
 
+    /**
+     * @return PredicateInterface<non-empty-array<non-empty-string, mixed>>
+     */
     public function asPredicate(): PredicateInterface
     {
         return Predicate::of($this);


### PR DESCRIPTION
## Problem

The type transitions defined in the `Constraint` interface are not inherited by Psalm for the classes implementing this interface.

This resulted in Psalm thinking all values after a composition were `mixed`.

## Solution

Duplicate the types transitions on each class implementing `Constraint`.