### PR TITLE
Remove the need for `Constraint::map()` `callable`s to be pure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- `Constraint::map()` callable no longer needs to be pure
+
 ## 1.6.1 - 2024-11-11
 
 ### Fixed

--- a/src/AndConstraint.php
+++ b/src/AndConstraint.php
@@ -83,7 +83,7 @@ final class AndConstraint implements Constraint
     /**
      * @template T
      *
-     * @param pure-callable(C): T $map
+     * @param callable(C): T $map
      *
      * @return Constraint<A, T>
      */

--- a/src/AssociativeArray.php
+++ b/src/AssociativeArray.php
@@ -73,7 +73,7 @@ final class AssociativeArray implements Constraint
     /**
      * @template T
      *
-     * @param pure-callable(Map<K, V>): T $map
+     * @param callable(Map<K, V>): T $map
      *
      * @return Constraint<mixed, T>
      */

--- a/src/Constraint.php
+++ b/src/Constraint.php
@@ -42,7 +42,7 @@ interface Constraint
     /**
      * @template T
      *
-     * @param pure-callable(O): T $map
+     * @param callable(O): T $map
      *
      * @return self<I, T>
      */

--- a/src/Each.php
+++ b/src/Each.php
@@ -83,7 +83,7 @@ final class Each implements Constraint
     /**
      * @template V
      *
-     * @param pure-callable(list<T>): V $map
+     * @param callable(list<T>): V $map
      *
      * @return Constraint<list, V>
      */

--- a/src/Has.php
+++ b/src/Has.php
@@ -90,7 +90,7 @@ final class Has implements Constraint
     /**
      * @template T
      *
-     * @param pure-callable(mixed): T $map
+     * @param callable(mixed): T $map
      *
      * @return Constraint<array, T>
      */

--- a/src/Instance.php
+++ b/src/Instance.php
@@ -79,7 +79,7 @@ final class Instance implements Constraint
     /**
      * @template V
      *
-     * @param pure-callable(T): V $map
+     * @param callable(T): V $map
      *
      * @return Constraint<mixed, V>
      */

--- a/src/Is.php
+++ b/src/Is.php
@@ -219,7 +219,7 @@ final class Is implements Constraint
     /**
      * @template V
      *
-     * @param pure-callable(U): V $map
+     * @param callable(U): V $map
      *
      * @return Constraint<T, V>
      */

--- a/src/Map.php
+++ b/src/Map.php
@@ -19,12 +19,12 @@ final class Map implements Constraint
 {
     /** @var Constraint<I, O> */
     private Constraint $constraint;
-    /** @var pure-callable(O): T */
+    /** @var callable(O): T */
     private $map;
 
     /**
      * @param Constraint<I, O> $constraint
-     * @param pure-callable(O): T $map
+     * @param callable(O): T $map
      */
     private function __construct(Constraint $constraint, callable $map)
     {
@@ -34,6 +34,7 @@ final class Map implements Constraint
 
     public function __invoke(mixed $value): Validation
     {
+        /** @psalm-suppress ImpureFunctionCall */
         return ($this->constraint)($value)->map($this->map);
     }
 
@@ -44,7 +45,7 @@ final class Map implements Constraint
      * @psalm-pure
      *
      * @param Constraint<A, B> $constraint
-     * @param pure-callable(B): C $map
+     * @param callable(B): C $map
      *
      * @return self<A, B, C>
      */
@@ -80,7 +81,7 @@ final class Map implements Constraint
     /**
      * @template V
      *
-     * @param pure-callable(T): V $map
+     * @param callable(T): V $map
      *
      * @return self<I, T, V>
      */

--- a/src/Of.php
+++ b/src/Of.php
@@ -73,7 +73,7 @@ final class Of implements Constraint
     /**
      * @template T
      *
-     * @param pure-callable(B): T $map
+     * @param callable(B): T $map
      *
      * @return Constraint<A, T>
      */

--- a/src/OrConstraint.php
+++ b/src/OrConstraint.php
@@ -83,7 +83,7 @@ final class OrConstraint implements Constraint
     /**
      * @template T
      *
-     * @param pure-callable(B|C): T $map
+     * @param callable(B|C): T $map
      *
      * @return Constraint<A, T>
      */

--- a/src/PointInTime.php
+++ b/src/PointInTime.php
@@ -90,7 +90,7 @@ final class PointInTime implements Constraint
     /**
      * @template T
      *
-     * @param pure-callable(PointInTimeInterface): T $map
+     * @param callable(PointInTimeInterface): T $map
      *
      * @return Constraint<string, T>
      */

--- a/src/Shape.php
+++ b/src/Shape.php
@@ -187,7 +187,7 @@ final class Shape implements Constraint
     /**
      * @template T
      *
-     * @param pure-callable(non-empty-array<non-empty-string, mixed>): T $map
+     * @param callable(non-empty-array<non-empty-string, mixed>): T $map
      *
      * @return Constraint<mixed, T>
      */


### PR DESCRIPTION
## Problem

Even though technically the map `callable` must be pure for the `Constraint` to be pure, it's sometimes necessary to depend on an impure context to map the value. In the end this generates `InvalidArgument` by Psalm that doesn't help the program to be safer.

Users then need to write `psalm-suppress` annotations in their code to fix this.

This also prevents users to use third party packages that don't declare the purity of the code.

## Solution

Remove the need for the `callable`s to be pure.