### PR TITLE
Add constraints for specific cases of `string`s and `int`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - `Innmind\Validation\Constraint::object()`
 - `Innmind\Validation\Constraint::failWith()`
 - `Innmind\Validation\Constraint::string()->nonEmpty()`
+- `Innmind\Validation\Constraint::int()->positive()`
+- `Innmind\Validation\Constraint::int()->negative()`
+- `Innmind\Validation\Constraint::int()->range()`
 - `Innmind\Validation\Constraint\Provider`
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `Innmind\Validation\Constraint::object()`
 - `Innmind\Validation\Constraint::failWith()`
+- `Innmind\Validation\Constraint::string()->nonEmpty()`
 - `Innmind\Validation\Constraint\Provider`
 
 ### Changed

--- a/docs/constraints/primitives.md
+++ b/docs/constraints/primitives.md
@@ -7,6 +7,13 @@
     $validate = Is::string();
     ```
 
+=== "`non-empty-string`"
+    ```php
+    use Innmind\Validation\Is;
+
+    $validate = Is::string()->nonEmpty();
+    ```
+
 === "`int`"
     ```php
     use Innmind\Validation\Is;

--- a/docs/constraints/primitives.md
+++ b/docs/constraints/primitives.md
@@ -21,6 +21,30 @@
     $validate = Is::int();
     ```
 
+=== "`int<1, max>`"
+    ```php
+    use Innmind\Validation\Is;
+
+    $validate = Is::int()->positive();
+    ```
+
+=== "`int<min, -1>`"
+    ```php
+    use Innmind\Validation\Is;
+
+    $validate = Is::int()->negative();
+    ```
+
+=== "`int` range"
+    ```php
+    use Innmind\Validation\Is;
+
+    $min = 0;
+    $max = 100;
+
+    $validate = Is::int()->range($min, $max);
+    ```
+
 === "`float`"
     ```php
     use Innmind\Validation\Is;

--- a/proofs/is.php
+++ b/proofs/is.php
@@ -55,6 +55,68 @@ return static function() {
     );
 
     yield proof(
+        'Is::string()->nonEmpty()',
+        given(
+            Set::strings()->atLeast(1),
+            Set::either(
+                Set::integers(),
+                Set::realNumbers(),
+                Set::of(
+                    true,
+                    false,
+                    null,
+                    new stdClass,
+                ),
+                Set::sequence(Set::strings()),
+            ),
+        ),
+        static function($assert, $string, $other) {
+            $constraint = Is::string()->nonEmpty();
+
+            $assert->true(
+                $constraint->asPredicate()($string),
+            );
+            $assert->same(
+                $string,
+                $constraint($string)->match(
+                    static fn($value) => $value,
+                    static fn() => null,
+                ),
+            );
+            $assert->false(
+                $constraint->asPredicate()($other),
+            );
+            $assert->same(
+                [['$', 'Value is not of type string']],
+                $constraint($other)->match(
+                    static fn() => null,
+                    static fn($failures) => $failures
+                        ->map(static fn($failure) => [
+                            $failure->path()->toString(),
+                            $failure->message(),
+                        ])
+                        ->toList(),
+                ),
+            );
+            $assert->false(
+                $constraint->asPredicate()(''),
+            );
+            $assert->same(
+                [['$', 'String cannot be empty']],
+                $constraint('')->match(
+                    static fn() => null,
+                    static fn($failures) => $failures
+                        ->map(static fn($failure) => [
+                            $failure->path()->toString(),
+                            $failure->message(),
+                        ])
+                        ->toList(),
+                ),
+            );
+        },
+    );
+
+    yield proof(
         'Is::string()->withFailure()',
         given(
             Set::strings()->atLeast(1),

--- a/src/Constraint.php
+++ b/src/Constraint.php
@@ -70,12 +70,10 @@ final class Constraint
 
     /**
      * @psalm-pure
-     *
-     * @return self<mixed, int>
      */
-    public static function int(): self
+    public static function int(): Provider\Integer
     {
-        return new self(Constraint\Primitive::int());
+        return Provider\Integer::of(self::build(...));
     }
 
     /**

--- a/src/Constraint.php
+++ b/src/Constraint.php
@@ -62,12 +62,10 @@ final class Constraint
 
     /**
      * @psalm-pure
-     *
-     * @return self<mixed, string>
      */
-    public static function string(): self
+    public static function string(): Provider\Str
     {
-        return new self(Constraint\Primitive::string());
+        return Provider\Str::of(self::build(...));
     }
 
     /**

--- a/src/Constraint/Like.php
+++ b/src/Constraint/Like.php
@@ -87,6 +87,18 @@ trait Like
     }
 
     /**
+     * @deprecated Use self::failWith(), this method exist for backaward compatibility
+     *
+     * @param non-empty-string $message
+     *
+     * @return Constraint<I, O>
+     */
+    public function withFailure(string $message): Constraint
+    {
+        return $this->failWith($message);
+    }
+
+    /**
      * @return Predicate<O>
      */
     public function asPredicate(): Predicate

--- a/src/Constraint/Provider/Integer.php
+++ b/src/Constraint/Provider/Integer.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Validation\Constraint\Provider;
+
+use Innmind\Validation\{
+    Constraint,
+    Constraint\Provider,
+    Constraint\Implementation,
+    Constraint\Primitive,
+    Constraint\Like,
+    Failure,
+};
+use Innmind\Immutable\Validation;
+
+/**
+ * @psalm-immutable
+ * @implements Provider<mixed, int>
+ */
+final class Integer implements Provider
+{
+    /** @use Like<mixed, int> */
+    use Like;
+
+    /**
+     * @param pure-Closure(Implementation): Constraint $build
+     */
+    private function __construct(
+        private \Closure $build,
+    ) {
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     *
+     * @param pure-Closure(Implementation): Constraint $build
+     */
+    public static function of(\Closure $build): self
+    {
+        return new self($build);
+    }
+
+    #[\Override]
+    public function toConstraint(): Constraint
+    {
+        /** @var Constraint<mixed, int> */
+        return ($this->build)(Primitive::int());
+    }
+
+    /**
+     * @return Constraint<mixed, int<1, max>>
+     */
+    public function positive(): Constraint
+    {
+        return $this
+            ->toConstraint()
+            ->and(Constraint::of(static fn(int $int) => match (true) {
+                $int <= 0 => Validation::fail(Failure::of('Integer must be above 0')),
+                default => Validation::success($int),
+            }));
+    }
+
+    /**
+     * @return Constraint<mixed, int<min, -1>>
+     */
+    public function negative(): Constraint
+    {
+        return $this
+            ->toConstraint()
+            ->and(Constraint::of(static fn(int $int) => match (true) {
+                $int >= 0 => Validation::fail(Failure::of('Integer must be below 0')),
+                default => Validation::success($int),
+            }));
+    }
+
+    /**
+     * @return Constraint<mixed, int>
+     */
+    public function range(int $min, int $max): Constraint
+    {
+        return $this
+            ->toConstraint()
+            ->and(Constraint::of(static fn(int $int) => match (true) {
+                $int < $min => Validation::fail(Failure::of("Integer cannot be lower than $min")),
+                $int > $max => Validation::fail(Failure::of("Integer cannot be higher than $max")),
+                default => Validation::success($int),
+            }));
+    }
+}

--- a/src/Constraint/Provider/Str.php
+++ b/src/Constraint/Provider/Str.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types = 1);
+
+namespace Innmind\Validation\Constraint\Provider;
+
+use Innmind\Validation\{
+    Constraint,
+    Constraint\Provider,
+    Constraint\Implementation,
+    Constraint\Primitive,
+    Constraint\Like,
+    Failure,
+};
+use Innmind\Immutable\Validation;
+
+/**
+ * @psalm-immutable
+ * @implements Provider<mixed, string>
+ */
+final class Str implements Provider
+{
+    /** @use Like<mixed, string> */
+    use Like;
+
+    /**
+     * @param pure-Closure(Implementation): Constraint $build
+     */
+    private function __construct(
+        private \Closure $build,
+    ) {
+    }
+
+    /**
+     * @internal
+     * @psalm-pure
+     *
+     * @param pure-Closure(Implementation): Constraint $build
+     */
+    public static function of(\Closure $build): self
+    {
+        return new self($build);
+    }
+
+    #[\Override]
+    public function toConstraint(): Constraint
+    {
+        /** @var Constraint<mixed, string> */
+        return ($this->build)(Primitive::string());
+    }
+
+    /**
+     * @return Constraint<mixed, non-empty-string>
+     */
+    public function nonEmpty(): Constraint
+    {
+        return $this
+            ->toConstraint()
+            ->and(Constraint::of(static fn(string $string) => match ($string) {
+                '' => Validation::fail(Failure::of('String cannot be empty')),
+                default => Validation::success($string),
+            }));
+    }
+}

--- a/src/Is.php
+++ b/src/Is.php
@@ -21,10 +21,8 @@ final class Is
 
     /**
      * @psalm-pure
-     *
-     * @return Constraint<mixed, string>
      */
-    public static function string(): Constraint
+    public static function string(): Provider\Str
     {
         return Constraint::string();
     }

--- a/src/Is.php
+++ b/src/Is.php
@@ -29,10 +29,8 @@ final class Is
 
     /**
      * @psalm-pure
-     *
-     * @return Constraint<mixed, int>
      */
-    public static function int(): Constraint
+    public static function int(): Provider\Integer
     {
         return Constraint::int();
     }


### PR DESCRIPTION
By adding these 2 new providers it allows for future constraints.